### PR TITLE
Adjust SHELLFLAGS in makefile to workaround make build issues

### DIFF
--- a/common.mk
+++ b/common.mk
@@ -18,7 +18,7 @@ include $(ROOT_DIR_RELATIVE)/versions.mk
 SHELL:=bash
 .ONESHELL:
 .EXPORT_ALL_VARIABLES:
-.SHELLFLAGS := -eu -o pipefail -c
+.SHELLFLAGS := -euc
 .DELETE_ON_ERROR:
 MAKEFLAGS += --no-builtin-rules
 


### PR DESCRIPTION
**What type of PR is this?**
/kind bug

**What this PR does / why we need it**:
All our Linux build systems use make version 3.82, which has a bug where it is not able to handle `SHELLFLAGS` parsing well and it further impacts the shell method invocation in the Makefile.
https://savannah.gnu.org/bugs/?func=detailitem&item_id=35397 has more details of the make bug.

This change tries to make the `SHELLFLAGS` as a single token for make to parse. Unfortunately that means we have to drop the `-o pipefail` flag because there is no shortened flag option for it. A cursory check in the corresponding common.mk file shows no command piping. This should be relatively safe to drop.

**Testing done**
Builds were failing locally. Now pass.